### PR TITLE
Add functionality to turn on/off Running lights for faders based on user in-call status

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "conf": "^10.0.1",
-    "discord-rpc": "^3.2.0",
+    "discord-rpc": "github:majorsimon/RPC",
     "midi-mixer-plugin": "^0.3.0"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
-    "@types/discord-rpc": "^3.0.5",
+    "@types/discord-rpc": "^4",
     "@types/node": "^15.12.1",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "conf": "^10.0.1",
-    "discord-rpc": "github:majorsimon/RPC",
+    "discord-rpc": "^4.0.1",
     "midi-mixer-plugin": "^0.3.0"
   },
   "bundledDependencies": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,7 @@ export class DiscordApi {
     "rpc.activities.write",
     "rpc.voice.read",
     "rpc.voice.write",
+    "rpc.notifications.read",
   ];
   private static syncGap = 1000 * 30;
 
@@ -116,8 +117,15 @@ export class DiscordApi {
     }
 
     this.rpc.subscribe("VOICE_SETTINGS_UPDATE", (data: VoiceSettings) => {
+      console.log("VOICE_SETTINGS_UPDATE event triggered");
       this.sync(data);
     });
+
+    this.rpc.subscribe("VOICE_CONNECTION_STATUS", (data: any) => {
+      console.log("VOICE_CONNECTION_STATUS event triggered");
+      this.syncRunning(data);
+    });
+
 
     $MM.setSettingsStatus("status", "Syncing voice settings...");
     this.settings = await this.rpc.getVoiceSettings();
@@ -328,6 +336,26 @@ export class DiscordApi {
 
     config.set(Keys.AuthToken, accessToken);
   }
+
+  private async syncRunning(data?: any) {
+    /**
+     * RPC client ain't really best at getting current connection status, so just
+     * wait for subs to tell us state 
+     */
+    console.log("Syncing voice connection status from: ", data);
+    if (!this.faders) return; 
+
+    if (!data.state) {
+      console.log("No state given!?")
+      return; 
+    };
+
+    const connected = data.state == "VOICE_CONNECTED";
+    this.faders[DiscordFader.InputVolume].running = connected;
+    this.faders[DiscordFader.OutputVolume].running = connected;
+
+    console.log("Finished syncing voice connection status from: ", data);
+  };
 
   private async sync(settings?: VoiceSettings) {
     this.settings = settings ?? (await this.rpc.getVoiceSettings());

--- a/src/api.ts
+++ b/src/api.ts
@@ -116,16 +116,25 @@ export class DiscordApi {
       }
     }
 
-    this.rpc.subscribe("VOICE_SETTINGS_UPDATE", (data: VoiceSettings) => {
-      console.log("VOICE_SETTINGS_UPDATE event triggered");
-      this.sync(data);
-    });
-
-    this.rpc.subscribe("VOICE_CONNECTION_STATUS", (data: any) => {
+    /**
+      * our own libs are well-typed. the 4.x TotallyTyped declarations have lagged (at least for .on and .subscribe signatures)
+      * so to force compilation (until fixed upstream), let ts ignore the .on and .subscribe lines (badbadnotgood)
+    */
+    // @ts-ignore
+    this.rpc.on("VOICE_CONNECTION_STATUS", (data: any) => {
       console.log("VOICE_CONNECTION_STATUS event triggered");
       this.syncRunning(data);
     });
-
+    // @ts-ignore
+    this.rpc.on("VOICE_SETTINGS_UPDATE", (data: VoiceSettings) => {
+      console.log("VOICE_SETTINGS_UPDATE event triggered");
+      this.sync(data);
+    });
+    
+    // @ts-ignore
+    this.rpc.subscribe("VOICE_CONNECTION_STATUS", {}); 
+    // @ts-ignore
+    this.rpc.subscribe("VOICE_SETTINGS_UPDATE", {}); 
 
     $MM.setSettingsStatus("status", "Syncing voice settings...");
     this.settings = await this.rpc.getVoiceSettings();


### PR DESCRIPTION
NB: upstream project discord-rpc has ...issues... with subscriptions. A PR to fix these in that project has been merged into a github fork majorsimon/RPC, replacing the dependency on npm "discord-rpc" with the GH repo, at least until upstream issue resolved (see discordjs/RPC#159). This _aims_ to resolve the issues with the subscriptions, but in reality it seems a little flaky? 